### PR TITLE
Fix 2007 special election for 41st district representative

### DIFF
--- a/2007/20070505__de__special__precinct.csv
+++ b/2007/20070505__de__special__precinct.csv
@@ -41,7 +41,6 @@ Sussex,09-41,State Assembly,41,Write-in,John Adkins,7
 Sussex,Total,State Assembly,41,Write-in,John Adkins,584
 Sussex,04-41,State Assembly,41,Write-in,Robert Johnson,1
 Sussex,05-41,State Assembly,41,Write-in,Bruce Collum,1
-Sussex,08-41,State Assembly,41,Write-in,Henry Mc Goul,1
+Sussex,08-41,State Assembly,41,Write-in,Henry Mc Goul,2
 Sussex,01-41,State Assembly,41,Write-in,G. G. Messick,1
-Sussex,01-41,State Assembly,41,Write-in,Greg Hastings,1
 Sussex,01-41,State Assembly,41,Write-in,Greg Hastings,1


### PR DESCRIPTION
According to [this source](https://elections.delaware.gov/archive/elect07/elect07_special_sen_41/elect07_special_sen_41.shtml), Henry McGoul received 2 write-in votes in district 08:

![image](https://user-images.githubusercontent.com/17345532/130334443-76266130-bc53-467c-a3e1-03a73faee196.png)

This also removes a duplcate write-in entry for Greg Hastings.