### PR TITLE
Narrow bare excepts to KeyError/IndexError in the DE parsers

### DIFF
--- a/src/de-parser.py
+++ b/src/de-parser.py
@@ -149,7 +149,7 @@ class DEParser(object):
                                 try:
                                     county = self.district_lookup[line[0]]
                                     lastED = line[0]
-                                except:
+                                except (KeyError, IndexError):
                                     print(f"ERROR: Can't find ED: {line[0]}")
                                 election_district = line[0]
 
@@ -160,7 +160,7 @@ class DEParser(object):
                                 result = self.Result(county, election_district, chunk.office, chunk.district, candidate[1], candidate[0], clean(line[j]), clean(line[j+1]), clean(line[j+2]))
                                 # print(result)
                                 self.processed.append(result)
-                            except:
+                            except (KeyError, IndexError):
                                 print(f"ERROR: Failed adding result for {candidate} in ED-RD {line[0]}")
 
 

--- a/src/de-parser_pre-2005.py
+++ b/src/de-parser_pre-2005.py
@@ -150,7 +150,7 @@ class DEParser(object):
                                 try:
                                     county = self.district_lookup[line[0]]
                                     lastED = line[0]
-                                except:
+                                except (KeyError, IndexError):
                                     print(f"ERROR: Can't find ED: {line[0]}")
                                 election_district = line[0]
 
@@ -161,7 +161,7 @@ class DEParser(object):
                                 result = self.Result(county, election_district, chunk.office, chunk.district, candidate[1], candidate[0], clean(line[j]))
                                 # print(result)
                                 self.processed.append(result)
-                            except:
+                            except (KeyError, IndexError):
                                 print(f"ERROR: Failed adding result for {candidate} in ED-RD {line[0]}")
 
 


### PR DESCRIPTION
flake8 E722. The bare `except:` blocks wrap `district_lookup[line[0]]` and result-row builds, so KeyError / IndexError cover the actual failure modes.